### PR TITLE
feat: better rxObject typings

### DIFF
--- a/packages/rxjs-react/src/rx-object.ts
+++ b/packages/rxjs-react/src/rx-object.ts
@@ -4,11 +4,12 @@ import { Lens } from "@rixio/lens"
 import { map } from "rxjs/operators"
 
 
-type InferObservableValue<O extends ObservableLike<any>> = O extends Observable<infer T> ? T : O
-type InferObservableInTuple<A extends [...ObservableLike<any>[]]> = { [I in keyof A]: InferObservableValue<A[I]> }
-type InferLiftedValue<L extends Lifted<any>> = L extends Lifted<infer T> ? T : L
-export function rxObject<A extends [...ObservableLike<any>[]]>(lifted: [...A]): Observable<InferObservableInTuple<A>>
-export function rxObject<L extends Lifted<any>>(lifted: L): Observable<InferLiftedValue<L>>
+
+type InferObservableInTuple<T extends any[]> = {
+	[I in keyof T]: T[I] extends Observable<infer T> ? T : T[I]
+}
+export declare function rxObject<T extends any[]>(lifted: [...T]): Observable<InferObservableInTuple<T>>
+export declare function rxObject<T>(lifted: Lifted<T>): Observable<T>
 export function rxObject(lifted: any): Observable<any> {
 	const observables: Observable<any>[] = []
 	const lenses: Lens<Lifted<T>, any>[] = []

--- a/packages/rxjs-react/src/rx-object.ts
+++ b/packages/rxjs-react/src/rx-object.ts
@@ -4,7 +4,12 @@ import { Lens } from "@rixio/lens"
 import { map } from "rxjs/operators"
 
 
-export function rxObject<T>(lifted: Lifted<T>): Observable<T> {
+type InferObservableValue<O extends ObservableLike<any>> = O extends Observable<infer T> ? T : O
+type InferObservableInTuple<A extends [...ObservableLike<any>[]]> = { [I in keyof A]: InferObservableValue<A[I]> }
+type InferLiftedValue<L extends Lifted<any>> = L extends Lifted<infer T> ? T : L
+export function rxObject<A extends [...ObservableLike<any>[]]>(lifted: [...A]): Observable<InferObservableInTuple<A>>
+export function rxObject<L extends Lifted<any>>(lifted: L): Observable<InferLiftedValue<L>>
+export function rxObject(lifted: any): Observable<any> {
 	const observables: Observable<any>[] = []
 	const lenses: Lens<Lifted<T>, any>[] = []
 	walk(lifted, (value, lens) => {


### PR DESCRIPTION
Example
```
const o = rxObject({ a: of(5), blah: "blah" })
const a = rxObject([of(5), "blah"])
```