### PR TITLE
Improve "rxjs-atom-promise" package

### DIFF
--- a/packages/list/src/component.test.tsx
+++ b/packages/list/src/component.test.tsx
@@ -29,7 +29,7 @@ const Renderable = ({ loader, state }: RenderableProps) => (
 	>
 		{load => (
 			<section>
-				<Rx value$={state}>{s => s.items.map(x => <span>{x}</span>)}</Rx>
+				<Rx value$={state}>{s => s.items.map((x, i) => <span key={i}>{x}</span>)}</Rx>
 				<Rx
 					value$={reactiveList(state.view("items"), x => (
 						<span key={x} data-testid={`item_${x}`}>

--- a/packages/rxjs-atom-promise/package.json
+++ b/packages/rxjs-atom-promise/package.json
@@ -32,8 +32,8 @@
     "@rixio/rxjs-react": "^0.6.2"
   },
   "devDependencies": {
-    "@testing-library/jest-dom": "5.11.4",
-    "@testing-library/react": "11.0.4",
+    "@testing-library/jest-dom": "5.11.5",
+    "@testing-library/react": "11.1.0",
     "@types/jest": "26.0.14",
     "immutable": "4.0.0-rc.12",
     "jest": "26.4.2",

--- a/packages/rxjs-atom-promise/src/cacheable.test.tsx
+++ b/packages/rxjs-atom-promise/src/cacheable.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/jsx-pascal-case */
 import { Atom } from "@rixio/rxjs-atom"
 import { act, render, waitFor, fireEvent } from "@testing-library/react"
 import React, { ReactElement, useRef } from "react"

--- a/packages/rxjs-atom-promise/src/promise-state.test.tsx
+++ b/packages/rxjs-atom-promise/src/promise-state.test.tsx
@@ -1,0 +1,67 @@
+import React from "react"
+import { act, render, waitFor } from "@testing-library/react"
+import { Atom } from "@rixio/rxjs-atom"
+import { flatMap, map } from "rxjs/operators"
+import {
+	createPromiseStatePending,
+	createPromiseStateFulfilled,
+	mapPromiseState,
+	mapPromiseStateAsync,
+} from "./promise-state"
+import { Rx } from "./rx"
+
+describe("Promise-state", () => {
+	test("should map promise state", () => {
+		const state$ = Atom.create(createPromiseStatePending<number>())
+		const mappedState$ = state$.pipe(map(mapPromiseState(x => x + 1)))
+		const r = render(
+			<React.Fragment>
+				<span data-testid="test">
+					<Rx value$={state$} pending="pending">
+						{v => <span>{v}</span>}
+					</Rx>
+				</span>
+				<span data-testid="test-mapped">
+					<Rx value$={mappedState$} pending="pending">
+						{v => <span>{v}</span>}
+					</Rx>
+				</span>
+			</React.Fragment>
+		)
+		expect(r.getByTestId("test")).toHaveTextContent("pending")
+		expect(r.getByTestId("test-mapped")).toHaveTextContent("pending")
+		act(() => {
+			state$.set(createPromiseStateFulfilled(1))
+		})
+		expect(r.getByTestId("test")).toHaveTextContent("1")
+		expect(r.getByTestId("test-mapped")).toHaveTextContent("2")
+	})
+
+	test("should mergeMap promise state", async () => {
+		const state$ = Atom.create(createPromiseStatePending<number>())
+		const mappedState$ = state$.pipe(flatMap(mapPromiseStateAsync(x => Promise.resolve(x + 1))))
+		const r = render(
+			<React.Fragment>
+				<span data-testid="test">
+					<Rx value$={state$} pending="pending">
+						{v => <span>{v}</span>}
+					</Rx>
+				</span>
+				<span data-testid="test-mapped">
+					<Rx value$={mappedState$} pending="pending">
+						{v => <span>{v}</span>}
+					</Rx>
+				</span>
+			</React.Fragment>
+		)
+		expect(r.getByTestId("test")).toHaveTextContent("pending")
+		expect(r.getByTestId("test-mapped")).toHaveTextContent("pending")
+		act(() => {
+			state$.set(createPromiseStateFulfilled(1))
+		})
+		expect(r.getByTestId("test")).toHaveTextContent("1")
+		await waitFor(() => {
+			expect(r.getByTestId("test-mapped")).toHaveTextContent("2")
+		})
+	})
+})

--- a/packages/rxjs-atom-promise/src/promise-state.ts
+++ b/packages/rxjs-atom-promise/src/promise-state.ts
@@ -51,11 +51,33 @@ export const createPromiseStatePending = <T>(emptyValue?: T): PromiseState<T> =>
 
 export function mapPromiseState<F, T>(mapper: (value: F) => T): (state: PromiseState<F>) => PromiseState<T> {
 	return state => {
-		let value: T | undefined
-		if (state.value) {
-			value = mapper(state.value)
+		if (state.status === "fulfilled") {
+			return {
+				status: state.status,
+				value: mapper(state.value),
+			} as PromiseState<T>
 		}
-		return { ...state, value: value as T }
+		return {
+			status: state.status,
+			value: state.value as any,
+		} as PromiseState<T>
+	}
+}
+
+export function mapPromiseStateAsync<F, T>(
+	mapper: (value: F) => Promise<T>
+): (state: PromiseState<F>) => Promise<PromiseState<T>> {
+	return async state => {
+		if (state.status === "fulfilled") {
+			return {
+				status: state.status,
+				value: await mapper(state.value),
+			} as PromiseState<T>
+		}
+		return {
+			status: state.status,
+			value: state.value as any,
+		} as PromiseState<T>
 	}
 }
 

--- a/packages/rxjs-atom-promise/src/rx.test.tsx
+++ b/packages/rxjs-atom-promise/src/rx.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/jsx-pascal-case */
 import React, { ReactElement } from "react"
 import { act, render, waitFor } from "@testing-library/react"
 import { Atom } from "@rixio/rxjs-atom"

--- a/packages/rxjs-atom-promise/src/rx.test.tsx
+++ b/packages/rxjs-atom-promise/src/rx.test.tsx
@@ -8,8 +8,7 @@ import { PromiseState, createPromiseStatePending, createPromiseStateFulfilled } 
 import { Rx } from "./rx"
 
 describe("Rx", () => {
-	test("should display pending if is pending", async () => {
-		expect.assertions(2)
+	test("should display pending if is pending", () => {
 		const state$ = Atom.create(createPromiseStatePending<string>())
 		const r = render(
 			<span data-testid="test">
@@ -18,12 +17,11 @@ describe("Rx", () => {
 				</Rx>
 			</span>
 		)
-		await expect(r.getByTestId("test")).toHaveTextContent("pending")
-		await expect(r.getByTestId("test")).not.toHaveTextContent("content")
+		expect(r.getByTestId("test")).toHaveTextContent("pending")
+		expect(r.getByTestId("test")).not.toHaveTextContent("content")
 	})
 
-	test("should not display pending if handlePending=none", async () => {
-		expect.assertions(2)
+	test("should not display pending if handlePending=none", () => {
 		const state$ = Atom.create(createPromiseStatePending<string>())
 		const r = render(
 			<span data-testid="test">
@@ -32,13 +30,12 @@ describe("Rx", () => {
 				</Rx>
 			</span>
 		)
-		await expect(r.getByTestId("test")).not.toHaveTextContent("pending")
+		expect(r.getByTestId("test")).not.toHaveTextContent("pending")
 		act(() => state$.set(createPromiseStateFulfilled("content")))
-		await expect(r.getByTestId("test")).toHaveTextContent("content")
+		expect(r.getByTestId("test")).toHaveTextContent("content")
 	})
 
-	test("should display pending only first time when handlePending=initial", async () => {
-		expect.assertions(3)
+	test("should display pending only first time when handlePending=initial", () => {
 		const state$ = Atom.create(createPromiseStatePending<string>())
 		const r = render(
 			<span data-testid="test">
@@ -47,15 +44,15 @@ describe("Rx", () => {
 				</Rx>
 			</span>
 		)
-		await expect(r.getByTestId("test")).toHaveTextContent("pending")
+		expect(r.getByTestId("test")).toHaveTextContent("pending")
 		act(() => state$.set(createPromiseStateFulfilled("content")))
-		await expect(r.getByTestId("test")).toHaveTextContent("content")
+		expect(r.getByTestId("test")).toHaveTextContent("content")
 		act(() => state$.lens("status").set("pending"))
-		await expect(r.getByTestId("test")).not.toHaveTextContent("pending")
+		expect(r.getByTestId("test")).not.toHaveTextContent("pending")
 	})
 
-	test("should display content if loaded", async () => {
-		testPromiseState(state$ => (
+	test("should display content if loaded", () => {
+		return testPromiseState(state$ => (
 			<span data-testid="test">
 				<Rx value$={state$} pending="pending">
 					{value => <span>{value}</span>}
@@ -64,7 +61,7 @@ describe("Rx", () => {
 		))
 	})
 
-	test("should display content if simple observable is used", async () => {
+	test("should display content if simple observable is used", () => {
 		const subj = new ReplaySubject<number>(1)
 		const r = render(
 			<span data-testid="test">
@@ -76,12 +73,12 @@ describe("Rx", () => {
 		act(() => {
 			subj.next(number)
 		})
-		await waitFor(() => {
+		return waitFor(() => {
 			expect(r.getByTestId("test")).toHaveTextContent(number.toString())
 		})
 	})
 
-	test("should display error if simple observable is used", async () => {
+	test("should display error if simple observable is used", () => {
 		const subj = new ReplaySubject<number>(1)
 		const r = render(
 			<span data-testid="test">
@@ -91,15 +88,17 @@ describe("Rx", () => {
 		expect(r.getByTestId("test")).toHaveTextContent("pending")
 		const text = Math.random().toString()
 		act(() => {
-			subj.error(text)
+			try {
+				subj.error(text)
+			} catch (_) {}
 		})
-		await waitFor(() => {
+		return waitFor(() => {
 			expect(r.getByTestId("test")).toHaveTextContent(text)
 		})
 	})
 
-	test("should display content if children empty", async () => {
-		testPromiseState(state$ => (
+	test("should display content if children empty", () => {
+		return testPromiseState(state$ => (
 			<span data-testid="test">
 				<Rx value$={state$} pending="pending" />
 			</span>
@@ -107,7 +106,7 @@ describe("Rx", () => {
 	})
 
 	test("should work if render prop is not used", () => {
-		testPromiseState(state$ => (
+		return testPromiseState(state$ => (
 			<span data-testid="test">
 				<Rx value$={state$} pending="pending">
 					simple text
@@ -118,14 +117,14 @@ describe("Rx", () => {
 		))
 	})
 
-	test("should work with null atom's value", async () => {
+	test("should work with null atom's value", () => {
 		const state$ = Atom.create(null)
 		const r = render(
 			<span data-testid="test">
 				<Rx value$={state$}>{v => <span>{`${v}`}</span>}</Rx>
 			</span>
 		)
-		await expect(r.getByTestId("test")).toHaveTextContent("null")
+		return expect(r.getByTestId("test")).toHaveTextContent("null")
 	})
 })
 
@@ -137,5 +136,7 @@ function testPromiseState(comp: (state: Atom<PromiseState<number>>) => ReactElem
 	act(() => {
 		state$.set(createPromiseStateFulfilled(number))
 	})
-	expect(r.getByTestId("test")).toHaveTextContent(number.toString())
+	return waitFor(() => {
+		expect(r.getByTestId("test")).toHaveTextContent(number.toString())
+	})
 }

--- a/packages/rxjs-atom/src/atom.test.ts
+++ b/packages/rxjs-atom/src/atom.test.ts
@@ -759,6 +759,7 @@ describe("atom", () => {
 				}
 			})
 
+			// eslint-disable-next-line @typescript-eslint/no-unused-vars
 			const _ = Atom.fromObservable(src)
 
 			expect(subscribed).toEqual(false)

--- a/packages/rxjs-atom/src/base.ts
+++ b/packages/rxjs-atom/src/base.ts
@@ -269,10 +269,6 @@ export abstract class AbstractAtom<T> extends AbstractReadOnlyAtom<T> implements
 }
 
 export class JsonAtom<T> extends AbstractAtom<T> {
-	constructor(initialValue: T) {
-		super(initialValue)
-	}
-
 	get() {
 		return this.getValue()
 	}

--- a/packages/rxjs-react/package.json
+++ b/packages/rxjs-react/package.json
@@ -33,8 +33,8 @@
   },
   "devDependencies": {
     "@rixio/rxjs-atom": "^0.3.3",
-    "@testing-library/jest-dom": "5.11.4",
-    "@testing-library/react": "11.0.4",
+    "@testing-library/jest-dom": "5.11.5",
+    "@testing-library/react": "11.1.0",
     "@types/jest": "26.0.14",
     "@types/react": "16.9.37",
     "@types/react-dom": "16.9.8",

--- a/packages/rxjs-react/src/rx-html.test.tsx
+++ b/packages/rxjs-react/src/rx-html.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/jsx-pascal-case */
 import { act, render } from "@testing-library/react"
 import { ReplaySubject } from "rxjs"
 import React from "react"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2086,10 +2086,10 @@
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
-"@testing-library/dom@^7.24.2":
-  version "7.24.3"
-  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-7.24.3.tgz#dae3071463cf28dc7755b43d9cf2202e34cbb85d"
-  integrity sha512-6eW9fUhEbR423FZvoHRwbWm9RUUByLWGayYFNVvqTnQLYvsNpBS4uEuKH9aqr3trhxFwGVneJUonehL3B1sHJw==
+"@testing-library/dom@^7.26.0":
+  version "7.26.3"
+  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-7.26.3.tgz#5554ee985f712d621bd676104b879f85d9a7a0ef"
+  integrity sha512-/1P6taENE/H12TofJaS3L1J28HnXx8ZFhc338+XPR5y1E3g5ttOgu86DsGnV9/n2iPrfJQVUZ8eiGYZGSxculw==
   dependencies:
     "@babel/code-frame" "^7.10.4"
     "@babel/runtime" "^7.10.3"
@@ -2097,12 +2097,13 @@
     aria-query "^4.2.2"
     chalk "^4.1.0"
     dom-accessibility-api "^0.5.1"
+    lz-string "^1.4.4"
     pretty-format "^26.4.2"
 
-"@testing-library/jest-dom@5.11.4":
-  version "5.11.4"
-  resolved "https://registry.yarnpkg.com/@testing-library/jest-dom/-/jest-dom-5.11.4.tgz#f325c600db352afb92995c2576022b35621ddc99"
-  integrity sha512-6RRn3epuweBODDIv3dAlWjOEHQLpGJHB2i912VS3JQtsD22+ENInhdDNl4ZZQiViLlIfFinkSET/J736ytV9sw==
+"@testing-library/jest-dom@5.11.5":
+  version "5.11.5"
+  resolved "https://registry.yarnpkg.com/@testing-library/jest-dom/-/jest-dom-5.11.5.tgz#44010f37f4b1e15f9d433963b515db0b05182fc8"
+  integrity sha512-XI+ClHR864i6p2kRCEyhvpVejuer+ObVUF4cjCvRSF88eOMIfqw7RoS9+qoRhyigGswMfT64L6Nt0Ufotxbwtg==
   dependencies:
     "@babel/runtime" "^7.9.2"
     "@types/testing-library__jest-dom" "^5.9.1"
@@ -2125,13 +2126,13 @@
     ramda "^0.26.1"
     redent "^2.0.0"
 
-"@testing-library/react@11.0.4":
-  version "11.0.4"
-  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-11.0.4.tgz#c84082bfe1593d8fcd475d46baee024452f31dee"
-  integrity sha512-U0fZO2zxm7M0CB5h1+lh31lbAwMSmDMEMGpMT3BUPJwIjDEKYWOV4dx7lb3x2Ue0Pyt77gmz/VropuJnSz/Iew==
+"@testing-library/react@11.1.0":
+  version "11.1.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-11.1.0.tgz#dfb4b3177d05a8ccf156b5fd14a5550e91d7ebe4"
+  integrity sha512-Nfz58jGzW0tgg3irmTB7sa02JLkLnCk+QN3XG6WiaGQYb0Qc4Ok00aujgjdxlIQWZHbb4Zj5ZOIeE9yKFSs4sA==
   dependencies:
     "@babel/runtime" "^7.11.2"
-    "@testing-library/dom" "^7.24.2"
+    "@testing-library/dom" "^7.26.0"
 
 "@types/aria-query@^4.2.0":
   version "4.2.0"
@@ -7187,6 +7188,11 @@ lru-cache@^5.1.1:
   integrity sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==
   dependencies:
     yallist "^3.0.2"
+
+lz-string@^1.4.4:
+  version "1.4.4"
+  resolved "https://registry.yarnpkg.com/lz-string/-/lz-string-1.4.4.tgz#c0d8eaf36059f705796e1e344811cf4c498d3a26"
+  integrity sha1-wNjq82BZ9wV5bh40SBHPTEmNOiY=
 
 macos-release@^2.2.0:
   version "2.4.1"


### PR DESCRIPTION
- Add `mapPromiseStateAsync` function to `rxjs-atom-promise` for work with flatMap/mergeMap 
- Add tests for `mapPromiseState`, `mapPromiseStateAsync`
- Fix tests (partly) for `Rx` component from `rxjs-atom-promise` package
