### PR TITLE
fix: lens number

### DIFF
--- a/packages/atom/src/atom.test.ts
+++ b/packages/atom/src/atom.test.ts
@@ -382,6 +382,20 @@ describe("atom", () => {
 				)
 			)
 		)
+
+		describe("string key lens then atom.get", () => {
+			const x1 = Atom.create({ y: { x: 123 } })
+			const x2 = x1.lens("y")
+
+			expect(x2.get()).toMatchObject({ x: 123 })
+		})
+
+		describe("number key lens then atom.get", () => {
+			const x1 = Atom.create([{ x: 123 }])
+			const x2 = x1.lens(0)
+
+			expect(x2.get()).toMatchObject({ x: 123 })
+		})
 	})
 
 	describe("view", () => {

--- a/packages/atom/src/base.ts
+++ b/packages/atom/src/base.ts
@@ -263,7 +263,9 @@ export abstract class AbstractAtom<T> extends AbstractReadOnlyAtom<T> implements
 
 	lens<U>(arg1: Lens<T, U> | string, ...args: string[]): Atom<any> {
 		const lens =
-			typeof arg1 === "string" ? Lens.compose(Lens.key(arg1), ...args.map(k => Lens.key(k))) : (arg1 as Lens<T, U>)
+			typeof arg1 === "string" || typeof arg1 === "number"
+				? Lens.compose(Lens.key(arg1), ...args.map(k => Lens.key(k)))
+				: (arg1 as Lens<T, U>)
 
 		return this.lensedAtomsCache.getOrCreate(lens)
 	}


### PR DESCRIPTION
Error case:

```js
console.error(`before error`)
const arr$ = Atom.create(["hello", "world"])
const item2$ = arr$.lens(1)
const item2 = useAtom(item2$)
console.error(`item2`, { item2 })
```

useAtom calls item2$._lens.get but _lens is "1" here